### PR TITLE
Valid login attempts resulting in "Invalid Credentials"

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -185,6 +185,9 @@ class Manager
      */
     protected function retrieveByCredentials(array $credentials)
     {
+        // Retrieve new query builder
+        $query = $this->model->newQuery();
+
         foreach ($credentials as $key => $value) {
             // Ignore sensitive fields
             if (in_array($key, $this->model->getHidden())) {
@@ -192,10 +195,10 @@ class Manager
             }
 
             // Add where condition
-            $this->model->where($key, '=', $value);
+            $query->where($key, '=', $value);
         }
 
-        return $this->model->first();
+        return $query->first();
     }
 
     /**


### PR DESCRIPTION
Fixed error that was making valid backend login attempts to throw an "Invalid Credentials" error. Basically , the where clauses where not being chained to a query but using the model itself. 

So when executing '$this->model->first()' it ended up selecting the first user on the database, ignoring the email provided and therefore failing to validate the password after that.
