### PR TITLE
Gate checks are now done on the controllers actions;

### DIFF
--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -26,10 +26,6 @@ class FailedJobsController extends Controller
      */
     public function __construct(FailedJobRepository $failedJobRepository)
     {
-        if (Gate::denies('backend-developer')) {
-            abort(403);
-        }
-
         $this->failedJobRepository = $failedJobRepository;
     }
 
@@ -42,6 +38,10 @@ class FailedJobsController extends Controller
      */
     public function index()
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve data
         $failedJobs = $this->failedJobRepository->getPaginatedForBackend();
 
@@ -57,6 +57,10 @@ class FailedJobsController extends Controller
      */
     public function restartAll()
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         Artisan::call('queue:retry', ['id' => ['all']]);
 
         return redirect()->route('nodes.backend.failed-jobs')->with('success', 'All failed job has been restarted');
@@ -72,6 +76,10 @@ class FailedJobsController extends Controller
      */
     public function restart($id)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         $failedJob = $this->failedJobRepository->getById($id);
         if (! $failedJob) {
             return redirect()->route('nodes.backend.failed-jobs')->with('error', 'Failed job does not exist');
@@ -92,6 +100,10 @@ class FailedJobsController extends Controller
      */
     public function forget($id)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         $failedJob = $this->failedJobRepository->getById($id);
         if (! $failedJob) {
             return redirect()->route('nodes.backend.failed-jobs')->with('error', 'Failed job does not exist');

--- a/src/Http/Controllers/RolesController.php
+++ b/src/Http/Controllers/RolesController.php
@@ -29,10 +29,6 @@ class RolesController extends Controller
      */
     public function __construct(RoleRepository $roleRepository)
     {
-        if (Gate::denies('backend-developer')) {
-            abort(403);
-        }
-
         $this->roleRepository = $roleRepository;
     }
 
@@ -45,6 +41,10 @@ class RolesController extends Controller
      */
     public function index()
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve all roles
         $roles = $this->roleRepository->getPaginatedForBackend();
 
@@ -61,6 +61,10 @@ class RolesController extends Controller
      */
     public function store(RoleValidator $roleValidator)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve posted data
         $data = Request::only('title');
 
@@ -91,6 +95,10 @@ class RolesController extends Controller
      */
     public function update($id)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve posted data
         $data = Request::only('title');
 
@@ -125,6 +133,10 @@ class RolesController extends Controller
      */
     public function destroy($id)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve role by ID
         $role = $this->roleRepository->getById($id);
         if (empty($role)) {
@@ -156,6 +168,10 @@ class RolesController extends Controller
      */
     public function setDefault($id)
     {
+        if (Gate::denies('backend-developer')) {
+            abort(403);
+        }
+
         // Retrieve role by ID
         $role = $this->roleRepository->getById($id);
         if (empty($role)) {


### PR DESCRIPTION
Checks are now done on the Controllers actions; Since Laravel 5.3 we cannot resolve authenticated users on the `__construct()` of controllers.
