### PR TITLE
Fix wrong reference to Hash facade;

### DIFF
--- a/src/Models/User/UserRepository.php
+++ b/src/Models/User/UserRepository.php
@@ -101,7 +101,7 @@ class UserRepository extends Repository
         $user = $this->getByOrFail('email', $email);
 
         // Validate password
-        if (! Hash::check($password, $user['password'])) {
+        if (! \Hash::check($password, $user['password'])) {
             throw new InvalidPasswordException('Password was incorrect. Try again.');
         }
 


### PR DESCRIPTION
This fixes a wrong call to the facade, leading to the failure of the `getByEmailAndPassword()` method.