### PR TITLE
Add type="button" attribute to the clear-input button

### DIFF
--- a/resources/views/partials/components/file-picker.blade.php
+++ b/resources/views/partials/components/file-picker.blade.php
@@ -9,7 +9,7 @@
             <i class="file-picker__icon fa"></i>
             <span class="file-picker__drop-text">Drop your file here</span>
 
-            <button class="btn btn-transparent btn-sm file-picker__clear">
+            <button type="button" class="btn btn-transparent btn-sm file-picker__clear">
                 <i class="fa fa-times"></i>
             </button>
         </div>


### PR DESCRIPTION
This will fix the issue where file input field is cleared when pressing enter in any other input field in a form.