### PR TITLE
Add 'nullable' validation to password field

### DIFF
--- a/src/Models/User/Validation/UserValidator.php
+++ b/src/Models/User/Validation/UserValidator.php
@@ -20,6 +20,7 @@ class UserValidator extends AbstractValidator
             'email' => ['required', 'email', 'unique:backend_users,email,{:id}', 'max:190'],
             'password' => [
                 'required_without:id',
+                'nullable',
                 'min:8',
                 'confirmed',
                 'regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\X])(?=.*[!$#%]).*$/'
@@ -30,6 +31,7 @@ class UserValidator extends AbstractValidator
         'update-password' => [
             'password' => [
                 'required_without:id',
+                'nullable',
                 'min:8',
                 'confirmed',
                 'regex:/^.*(?=.{3,})(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[\d\X])(?=.*[!$#%]).*$/'


### PR DESCRIPTION
In the UserValidator the password validation where we have 'required_without:id' should also have 'nullable' in the array.
As at the moment (in Laravel 5.5) even when the password is empty and the id is present the other validations in the array are still run (i.e. min:8 etc). So at the moment the user cannot be updated unless the password is being changed at the same time.