### PR TITLE
Laravel 5 6

### DIFF
--- a/src/Auth/Providers/Session.php
+++ b/src/Auth/Providers/Session.php
@@ -78,7 +78,7 @@ class Session implements Provider
             return $user;
         }
 
-        throw new UnauthorizedHttpException(null, 'Could not find user in either sessions or cookies', null, 401);
+        throw new UnauthorizedHttpException('', 'Could not find user in either sessions or cookies', null, 401);
     }
 
     /**


### PR DESCRIPTION
In the authenticate method in the Nodes\Backend\Auth\Providers\Session.php the UnauthorizedHttpException first argument is null, but the first argument needs to be a string (https://github.com/symfony/http-kernel/blob/master/Exception/UnauthorizedHttpException.php).

